### PR TITLE
directly convert msg to bytevector instead of making a copy first

### DIFF
--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -78,8 +78,8 @@ private[netty] final class Client(limit: Int) {
       val buf = msg.asInstanceOf[ByteBuf]
       val dst = Array.ofDim[Byte](buf.capacity())
       buf.getBytes(0, dst)
-      val bv = ByteVector.view(dst) // copy data (alternatives are insanely clunky)
-
+      val bv = ByteVector.view(dst) 
+      
       buf.release()
 
       // because this is run and not runAsync, we have backpressure propagation

--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -76,7 +76,10 @@ private[netty] final class Client(limit: Int) {
 
     override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
       val buf = msg.asInstanceOf[ByteBuf]
-      val bv = ByteVector.view(buf.nioBuffer)       // copy data (alternatives are insanely clunky)
+      val dst = Array.ofDim[Byte](buf.capacity())
+      buf.getBytes(0, dst)
+      val bv = ByteVector(dst) // copy data (alternatives are insanely clunky)
+
       buf.release()
 
       // because this is run and not runAsync, we have backpressure propagation

--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -75,7 +75,7 @@ private[netty] final class Client(limit: Int) {
 
     override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
       val buf = msg.asInstanceOf[ByteBuf]
-      val bv = ByteVector(buf.nioBuffer)       // copy data (alternatives are insanely clunky)
+      val bv = ByteVector.view(buf.nioBuffer)       // copy data (alternatives are insanely clunky)
       buf.release()
 
       // because this is run and not runAsync, we have backpressure propagation

--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -78,7 +78,7 @@ private[netty] final class Client(limit: Int) {
       val buf = msg.asInstanceOf[ByteBuf]
       val dst = Array.ofDim[Byte](buf.capacity())
       buf.getBytes(0, dst)
-      val bv = ByteVector(dst) // copy data (alternatives are insanely clunky)
+      val bv = ByteVector.view(dst) // copy data (alternatives are insanely clunky)
 
       buf.release()
 

--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -36,6 +36,7 @@ import _root_.io.netty.handler.codec._
 
 private[netty] final class Client(limit: Int) {
   // this isn't ugly or anything...
+  @volatile
   private var channel: _root_.io.netty.channel.Channel = _
 
   private val queue = async.boundedQueue[ByteVector](limit)

--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -34,12 +34,7 @@ import _root_.io.netty.channel.socket._
 import _root_.io.netty.channel.socket.nio._
 import _root_.io.netty.handler.codec._
 
-private[netty] final class Client(limit: Int) {
-  // this isn't ugly or anything...
-  @volatile
-  private var channel: _root_.io.netty.channel.Channel = _
-
-  private val queue = async.boundedQueue[ByteVector](limit)
+private[netty] final class Client(channel: _root_.io.netty.channel.Channel, queue: async.mutable.Queue[ByteVector]) {
 
   def read: Process[Task, ByteVector] = queue.dequeue
 
@@ -64,41 +59,43 @@ private[netty] final class Client(limit: Int) {
       _ <- queue.close
     } yield ()
   }
+}
 
-  private final class Handler extends ChannelInboundHandlerAdapter {
+private[netty] final class ClientHandler(queue: async.mutable.Queue[ByteVector]) extends ChannelInboundHandlerAdapter {
 
-    override def channelInactive(ctx: ChannelHandlerContext): Unit = {
-      // if the connection is remotely closed, we need to clean things up on our side
-      queue.close.run
+  override def channelInactive(ctx: ChannelHandlerContext): Unit = {
+    // if the connection is remotely closed, we need to clean things up on our side
+    queue.close.run
 
-      super.channelInactive(ctx)
-    }
+    super.channelInactive(ctx)
+  }
 
-    override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
-      val buf = msg.asInstanceOf[ByteBuf]
-      val dst = Array.ofDim[Byte](buf.capacity())
-      buf.getBytes(0, dst)
-      val bv = ByteVector.view(dst) 
-      
-      buf.release()
+  override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
+    val buf = msg.asInstanceOf[ByteBuf]
+    val dst = Array.ofDim[Byte](buf.capacity())
+    buf.getBytes(0, dst)
+    val bv = ByteVector.view(dst) 
+    
+    buf.release()
 
-      // because this is run and not runAsync, we have backpressure propagation
-      queue.enqueueOne(bv).run
-    }
+    // because this is run and not runAsync, we have backpressure propagation
+    queue.enqueueOne(bv).run
+  }
 
-    override def exceptionCaught(ctx: ChannelHandlerContext, t: Throwable): Unit = {
-      queue.fail(t).run
+  override def exceptionCaught(ctx: ChannelHandlerContext, t: Throwable): Unit = {
+    queue.fail(t).run
 
-      // super.exceptionCaught(ctx, t)
-    }
+    // super.exceptionCaught(ctx, t)
   }
 }
 
 private[netty] object Client {
   def apply(to: InetSocketAddress, config: ClientConfig)(implicit pool: ExecutorService): Task[Client] = Task delay {
-    val client = new Client(config.limit)
+    //val client = new Client(config.limit)
     val bootstrap = new Bootstrap
 
+    val queue = async.boundedQueue[ByteVector](config.limit)
+    
     bootstrap.group(Netty.workerGroup)
     bootstrap.channel(classOf[NioSocketChannel])
 
@@ -109,7 +106,7 @@ private[netty] object Client {
         ch.pipeline
           .addLast("frame encoding", new LengthFieldPrepender(4))
           .addLast("frame decoding", new LengthFieldBasedFrameDecoder(Int.MaxValue, 0, 4, 0, 4))
-          .addLast("incoming handler", new client.Handler)
+          .addLast("incoming handler", new ClientHandler(queue))
       }
     })
 
@@ -117,8 +114,8 @@ private[netty] object Client {
 
     for {
       _ <- Netty toTask connectF
-      _ <- Task delay {
-        client.channel = connectF.channel()
+      client <- Task delay {
+        new Client(connectF.channel(), queue)
       }
     } yield client
   } join

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -82,9 +82,14 @@ private[netty] class Server(bossGroup: NioEventLoopGroup, limit: Int) { server =
 
     override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
       val buf = msg.asInstanceOf[ByteBuf]
+      val dst = Array.ofDim[Byte](buf.capacity())
+      buf.getBytes(0, dst)
+      
+      val bv = ByteVector(dst)
+      
       // use a view to avoid coping the buf
       // should be safe since there'd be no chance msg gets modified later
-      val bv = ByteVector.view(buf.nioBuffer)       // copy data (alternatives are insanely clunky)
+//      val bv = ByteVector.view(buf.nioBuffer)       // copy data (alternatives are insanely clunky)
       buf.release()
 
       // because this is run and not runAsync, we have backpressure propagation

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -34,13 +34,7 @@ import _root_.io.netty.channel.socket._
 import _root_.io.netty.channel.socket.nio._
 import _root_.io.netty.handler.codec._
 
-private[netty] class Server(bossGroup: NioEventLoopGroup, limit: Int) { server =>
-  // this isn't ugly or anything...
-  @volatile
-  private var channel: _root_.io.netty.channel.Channel = _
-
-  // represents incoming connections
-  private val queue = async.boundedQueue[(InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])](limit)
+private[netty] class Server(bossGroup: NioEventLoopGroup, channel: _root_.io.netty.channel.Channel, queue: async.mutable.Queue[(InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])]) { server =>
 
   def listen: Process[Task, (InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])] =
     queue.dequeue
@@ -55,74 +49,74 @@ private[netty] class Server(bossGroup: NioEventLoopGroup, limit: Int) { server =
       }
     } yield ()
   }
+}
 
-  private final class Handler(channel: SocketChannel)(implicit pool: ExecutorService) extends ChannelInboundHandlerAdapter {
+private[netty] final class ServerHandler(channel: SocketChannel, queue: async.mutable.Queue[ByteVector], serverQueue: async.mutable.Queue[(InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])])(implicit pool: ExecutorService) extends ChannelInboundHandlerAdapter {
 
-    // data from a single connection
-    private val queue = async.boundedQueue[ByteVector](limit)
+  // data from a single connection
+  //private val queue = async.boundedQueue[ByteVector](limit)
 
-    override def channelActive(ctx: ChannelHandlerContext): Unit = {
-      val process: Process[Task, Exchange[ByteVector, ByteVector]] =
-        Process(Exchange(read, write)) onComplete Process.eval(shutdown).drain
+  override def channelActive(ctx: ChannelHandlerContext): Unit = {
+    val process: Process[Task, Exchange[ByteVector, ByteVector]] =
+      Process(Exchange(read, write)) onComplete Process.eval(shutdown).drain
 
-      // gross...
-      val addr = channel.remoteAddress.asInstanceOf[InetSocketAddress]
+    // gross...
+    val addr = channel.remoteAddress.asInstanceOf[InetSocketAddress]
 
-      server.queue.enqueueOne((addr, process)).run
+    serverQueue.enqueueOne((addr, process)).run
 
-      super.channelActive(ctx)
+    super.channelActive(ctx)
+  }
+
+  override def channelInactive(ctx: ChannelHandlerContext): Unit = {
+    // if the connection is remotely closed, we need to clean things up on our side
+    queue.close.run
+
+    super.channelInactive(ctx)
+  }
+
+  override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
+    val buf = msg.asInstanceOf[ByteBuf]
+    val dst = Array.ofDim[Byte](buf.capacity())
+    buf.getBytes(0, dst)
+    
+    val bv = ByteVector.view(dst)
+    
+    buf.release()
+
+    // because this is run and not runAsync, we have backpressure propagation
+    queue.enqueueOne(bv).run
+  }
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, t: Throwable): Unit = {
+    queue.fail(t).run
+
+    // super.exceptionCaught(ctx, t)
+  }
+
+  // do not call more than once!
+  private def read: Process[Task, ByteVector] = queue.dequeue
+
+  private def write: Sink[Task, ByteVector] = {
+    def inner(bv: ByteVector): Task[Unit] = {
+      Task delay {
+        val data = bv.toArray
+        val buf = channel.alloc().buffer(data.length)
+        buf.writeBytes(data)
+
+        Netty toTask channel.writeAndFlush(buf)
+      } join
     }
 
-    override def channelInactive(ctx: ChannelHandlerContext): Unit = {
-      // if the connection is remotely closed, we need to clean things up on our side
-      queue.close.run
+    // TODO termination
+    Process constant (inner _)
+  }
 
-      super.channelInactive(ctx)
-    }
-
-    override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
-      val buf = msg.asInstanceOf[ByteBuf]
-      val dst = Array.ofDim[Byte](buf.capacity())
-      buf.getBytes(0, dst)
-      
-      val bv = ByteVector.view(dst)
-      
-      buf.release()
-
-      // because this is run and not runAsync, we have backpressure propagation
-      queue.enqueueOne(bv).run
-    }
-
-    override def exceptionCaught(ctx: ChannelHandlerContext, t: Throwable): Unit = {
-      queue.fail(t).run
-
-      // super.exceptionCaught(ctx, t)
-    }
-
-    // do not call more than once!
-    private def read: Process[Task, ByteVector] = queue.dequeue
-
-    private def write: Sink[Task, ByteVector] = {
-      def inner(bv: ByteVector): Task[Unit] = {
-        Task delay {
-          val data = bv.toArray
-          val buf = channel.alloc().buffer(data.length)
-          buf.writeBytes(data)
-
-          Netty toTask channel.writeAndFlush(buf)
-        } join
-      }
-
-      // TODO termination
-      Process constant (inner _)
-    }
-
-    def shutdown: Task[Unit] = {
-      for {
-        _ <- Netty toTask channel.close()
-        _ <- queue.close
-      } yield ()
-    }
+  def shutdown: Task[Unit] = {
+    for {
+      _ <- Netty toTask channel.close()
+      _ <- queue.close
+    } yield ()
   }
 }
 
@@ -130,9 +124,12 @@ private[netty] object Server {
   def apply(bind: InetSocketAddress, config: ServerConfig)(implicit pool: ExecutorService): Task[Server] = Task delay {
     val bossGroup = new NioEventLoopGroup(config.numThreads)
 
-    val server = new Server(bossGroup, config.limit)
+    //val server = new Server(bossGroup, config.limit)
     val bootstrap = new ServerBootstrap
-
+    
+    val serverQueue = async.boundedQueue[(InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])](config.limit)
+    val handlerQueue = async.boundedQueue[ByteVector](config.limit)
+    
     bootstrap.group(bossGroup, Netty.workerGroup)
       .channel(classOf[NioServerSocketChannel])
       .childOption[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, config.keepAlive)
@@ -144,7 +141,7 @@ private[netty] object Server {
               .addLast("frame decoding", new LengthFieldBasedFrameDecoder(Int.MaxValue, 0, 4, 0, 4))
           }
 
-          ch.pipeline.addLast("incoming handler", new server.Handler(ch))
+          ch.pipeline.addLast("incoming handler", new ServerHandler(ch, handlerQueue, serverQueue))
         }
       })
 
@@ -152,8 +149,8 @@ private[netty] object Server {
 
     for {
       _ <- Netty toTask bindF
-      _ <- Task delay {
-        server.channel = bindF.channel()      // yeah!  I <3 Netty
+      server <- Task delay {
+        new Server(bossGroup, bindF.channel(), serverQueue) // yeah!  I <3 Netty
       }
     } yield server
   } join

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -87,9 +87,6 @@ private[netty] class Server(bossGroup: NioEventLoopGroup, limit: Int) { server =
       
       val bv = ByteVector.view(dst)
       
-      // use a view to avoid coping the buf
-      // should be safe since there'd be no chance msg gets modified later
-//      val bv = ByteVector.view(buf.nioBuffer)       // copy data (alternatives are insanely clunky)
       buf.release()
 
       // because this is run and not runAsync, we have backpressure propagation

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -36,6 +36,7 @@ import _root_.io.netty.handler.codec._
 
 private[netty] class Server(bossGroup: NioEventLoopGroup, limit: Int) { server =>
   // this isn't ugly or anything...
+  @volatile
   private var channel: _root_.io.netty.channel.Channel = _
 
   // represents incoming connections

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -85,7 +85,7 @@ private[netty] class Server(bossGroup: NioEventLoopGroup, limit: Int) { server =
       val dst = Array.ofDim[Byte](buf.capacity())
       buf.getBytes(0, dst)
       
-      val bv = ByteVector(dst)
+      val bv = ByteVector.view(dst)
       
       // use a view to avoid coping the buf
       // should be safe since there'd be no chance msg gets modified later

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -81,7 +81,9 @@ private[netty] class Server(bossGroup: NioEventLoopGroup, limit: Int) { server =
 
     override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
       val buf = msg.asInstanceOf[ByteBuf]
-      val bv = ByteVector(buf.nioBuffer)       // copy data (alternatives are insanely clunky)
+      // use a view to avoid coping the buf
+      // should be safe since there'd be no chance msg gets modified later
+      val bv = ByteVector.view(buf.nioBuffer)       // copy data (alternatives are insanely clunky)
       buf.release()
 
       // because this is run and not runAsync, we have backpressure propagation


### PR DESCRIPTION
this is to address one of the future work in wiki that aims to convert msg to bytevector directly instead of making a copy first.
