### PR TITLE
Strategy comes as implicit

### DIFF
--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -90,7 +90,7 @@ private[netty] final class ClientHandler(queue: async.mutable.Queue[ByteVector])
 }
 
 private[netty] object Client {
-  def apply(to: InetSocketAddress, config: ClientConfig)(implicit pool: ExecutorService): Task[Client] = Task delay {
+  def apply(to: InetSocketAddress, config: ClientConfig)(implicit pool: ExecutorService, S: Strategy): Task[Client] = Task delay {
     //val client = new Client(config.limit)
     val bootstrap = new Bootstrap
 

--- a/src/main/scala/scalaz/netty/Netty.scala
+++ b/src/main/scala/scalaz/netty/Netty.scala
@@ -40,13 +40,13 @@ object Netty {
     }
   })
 
-  def server(bind: InetSocketAddress, config: ServerConfig = ServerConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService): Process[Task, (InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])] = {
+  def server(bind: InetSocketAddress, config: ServerConfig = ServerConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService, S: Strategy): Process[Task, (InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])] = {
     Process.await(Server(bind, config)) { server: Server =>
       server.listen onComplete Process.eval(server.shutdown).drain
     }
   }
 
-  def connect(to: InetSocketAddress, config: ClientConfig = ClientConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService): Process[Task, Exchange[ByteVector, ByteVector]] = {
+  def connect(to: InetSocketAddress, config: ClientConfig = ClientConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService, S: Strategy): Process[Task, Exchange[ByteVector, ByteVector]] = {
     Process.await(Client(to, config)) { client: Client =>
       Process(Exchange(client.read, client.write)) onComplete Process.eval(client.shutdown).drain
     }

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -51,7 +51,7 @@ private[netty] class Server(bossGroup: NioEventLoopGroup, channel: _root_.io.net
   }
 }
 
-private[netty] final class ServerHandler(channel: SocketChannel, serverQueue: async.mutable.Queue[(InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])], limit: Int)(implicit pool: ExecutorService) extends ChannelInboundHandlerAdapter {
+private[netty] final class ServerHandler(channel: SocketChannel, serverQueue: async.mutable.Queue[(InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])], limit: Int)(implicit pool: ExecutorService, S: Strategy) extends ChannelInboundHandlerAdapter {
 
   // data from a single connection
   private val queue = async.boundedQueue[ByteVector](limit)
@@ -121,7 +121,7 @@ private[netty] final class ServerHandler(channel: SocketChannel, serverQueue: as
 }
 
 private[netty] object Server {
-  def apply(bind: InetSocketAddress, config: ServerConfig)(implicit pool: ExecutorService): Task[Server] = Task delay {
+  def apply(bind: InetSocketAddress, config: ServerConfig)(implicit pool: ExecutorService, S: Strategy): Task[Server] = Task delay {
     val bossGroup = new NioEventLoopGroup(config.numThreads)
 
     //val server = new Server(bossGroup, config.limit)


### PR DESCRIPTION
##### The problem:

With the default Strategy the enqueuing [here](https://github.com/RichRelevance/scalaz-netty/blob/master/src/main/scala/scalaz/netty/Client.scala#L82) happens on the default scalaz executor service and will block the netty-worker thread for the time being. Having a single client it's hard to notice it, but if you have multiple ones it starts to matter. Having a couple of clients will already introduce a measurable blocking on the worker thread. 

By getting the Strategy as a parameter a user has the possibility to define `Strategy.Sequential` and by doing that forcing the enqueue to happen on the netty worker thread. In our case we noticed about 30% improvement in throughput and also a little in latency. 
