### PR TITLE
isolated worker threads for server and client

### DIFF
--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -96,7 +96,7 @@ private[netty] object Client {
 
     val queue = async.boundedQueue[ByteVector](config.limit)
     
-    bootstrap.group(Netty.workerGroup)
+    bootstrap.group(Netty.clientWorkerGroup)
     bootstrap.channel(classOf[NioSocketChannel])
 
     bootstrap.option[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, config.keepAlive)

--- a/src/main/scala/scalaz/netty/Netty.scala
+++ b/src/main/scala/scalaz/netty/Netty.scala
@@ -30,15 +30,19 @@ import _root_.io.netty.channel.nio.NioEventLoopGroup
 
 object Netty {
 
-  private[netty] lazy val workerGroup = new NioEventLoopGroup(1, new ThreadFactory {
+  private[netty] def workerGroup(name: String) = new ThreadFactory {
     def newThread(r: Runnable): Thread = {
       val back = new Thread(r)
-      back.setName("netty-worker")
-      back.setDaemon(true)          // we're never going to clean this up
-      back.setPriority(8)           // get in, and get out.  fast.
+      back.setName(name)
+      back.setDaemon(true) // we're never going to clean this up
+      back.setPriority(8) // get in, and get out.  fast.
       back
     }
-  })
+  }
+
+  private[netty] lazy val clientWorkerGroup = new NioEventLoopGroup(1, workerGroup("netty-client-worker"))
+
+  private[netty] lazy val serverWorkerGroup = new NioEventLoopGroup(1, workerGroup("netty-server-worker"))
 
   def server(bind: InetSocketAddress, config: ServerConfig = ServerConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService): Process[Task, (InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])] = {
     Process.await(Server(bind, config)) { server: Server =>

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -129,7 +129,7 @@ private[netty] object Server {
 
     val serverQueue = async.boundedQueue[(InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])](config.limit)
 
-    bootstrap.group(bossGroup, Netty.workerGroup)
+    bootstrap.group(bossGroup, Netty.serverWorkerGroup)
       .channel(classOf[NioServerSocketChannel])
       .childOption[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, config.keepAlive)
       .childHandler(new ChannelInitializer[SocketChannel] {


### PR DESCRIPTION
By using the same worker thread for clients and servers, we couple them to tightly and by doing that possibly introduce performance penalties on one when actually the other is having difficulties. Consider having both a client and a server in the same application. If the client struggles keeping the pace it will block the worker thread which is also used by the server, hence it will indirectly block the server from making progress.

By introducing separate threads clients and servers are isolated. Note that the risk of having more clients or more servers influencing each other is still there.
