### PR TITLE
Back Pressure with Netty's setAutoread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ scala:
   - 2.11.7
   - 2.12.0-M2
 jdk:
-  - oraclejdk7
   - oraclejdk8

--- a/src/main/scala/scalaz/netty/BPAwareQueue.scala
+++ b/src/main/scala/scalaz/netty/BPAwareQueue.scala
@@ -1,0 +1,70 @@
+package scalaz.netty
+
+import java.util.concurrent.atomic.AtomicLong
+import io.netty.channel.ChannelConfig
+import scalaz.concurrent.{Strategy, Task}
+import scalaz.stream._
+
+
+/**
+ * A wrapper around async queue to implement back pressure by means of calling Netty's ChannelConfig.setAutoRead when needed.
+ *
+ * @param limit the target limit. It's the number of logical messages after which back pressure kicks in. Please note that the actual number of messages in the queue will be
+ * higher as netty will continue flushing its buffer.
+ *
+ * @tparam A the type of used messages
+ */
+private[netty] final class BPAwareQueue[A](val limit: Int) {
+
+  // we don't need a bound here as we do back pressure by calling channelConfig.setAutoRead
+  private val queue = async.unboundedQueue[A](Strategy.Sequential)
+
+  // we do the counting here as getting it from the async queue would introduce a latency
+  private val queueSize = new AtomicLong(0)
+
+  private val lowerBound: Int = Math.max(1, limit / 2)
+
+  def enqueueOne(channelConfig: ChannelConfig, a: A): Task[Unit] = Task.delay(enableBPIfNecessary(channelConfig)).flatMap(b => queue.enqueueOne(a))
+
+  def dequeue(channelConfig: ChannelConfig): Process[Task, A] = queue.dequeue.map { bv =>
+    disableBPIfNecessary(channelConfig)
+    bv
+  }
+
+  def close: Task[Unit] = queue.close
+
+  def fail(rsn: Throwable): Task[Unit] = queue.fail(rsn)
+
+  @inline
+  private def increase: Long = queueSize.incrementAndGet
+
+  @inline
+  private def decrease: Long = queueSize.decrementAndGet
+
+  /**
+   * This method needs to be called whenever the netty-worker thread calls us with a received message and we insert it into to the queue.
+   *
+   * As a side-effect it may disable auto-read should the queue size go above the limit
+   */
+  private def enableBPIfNecessary(channelConfig: ChannelConfig): Unit =
+    if (increase >= limit && channelConfig.isAutoRead) {
+      channelConfig.setAutoRead(false)
+    }
+
+
+  /**
+   * This method needs to be called when we dequeue a message form the message queue.
+   *
+   * As a side-effect it may enable autoread should the queue size go below half of the limit
+   *
+   */
+  private def disableBPIfNecessary(channelConfig: ChannelConfig): Unit =
+    if (decrease <= lowerBound && !channelConfig.isAutoRead) {
+      channelConfig.setAutoRead(true)
+    }
+
+}
+
+private[netty] final object BPAwareQueue {
+  def apply[A](limit: Int) = new BPAwareQueue[A](limit)
+}

--- a/src/main/scala/scalaz/netty/BPAwareQueue.scala
+++ b/src/main/scala/scalaz/netty/BPAwareQueue.scala
@@ -41,23 +41,11 @@ private[netty] final class BPAwareQueue[A](val limit: Int) {
   @inline
   private def decrease: Long = queueSize.decrementAndGet
 
-  /**
-   * This method needs to be called whenever the netty-worker thread calls us with a received message and we insert it into to the queue.
-   *
-   * As a side-effect it may disable auto-read should the queue size go above the limit
-   */
   private def enableBPIfNecessary(channelConfig: ChannelConfig): Unit =
     if (increase >= limit && channelConfig.isAutoRead) {
       channelConfig.setAutoRead(false)
     }
 
-
-  /**
-   * This method needs to be called when we dequeue a message form the message queue.
-   *
-   * As a side-effect it may enable autoread should the queue size go below half of the limit
-   *
-   */
   private def disableBPIfNecessary(channelConfig: ChannelConfig): Unit =
     if (decrease <= lowerBound && !channelConfig.isAutoRead) {
       channelConfig.setAutoRead(true)

--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -90,7 +90,7 @@ private[netty] final class ClientHandler(queue: BPAwareQueue[ByteVector]) extend
 }
 
 private[netty] object Client {
-  def apply(to: InetSocketAddress, config: ClientConfig)(implicit pool: ExecutorService): Task[Client] = Task delay {
+  def apply(to: InetSocketAddress, config: ClientConfig)(implicit pool: ExecutorService, S: Strategy): Task[Client] = Task delay {
     //val client = new Client(config.limit)
     val bootstrap = new Bootstrap
 

--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -94,11 +94,11 @@ private[netty] object Client {
     //val client = new Client(config.limit)
     val bootstrap = new Bootstrap
 
+
     val queue = BPAwareQueue[ByteVector](config.limit)
-
-    bootstrap.group(Netty.workerGroup)
+    
+    bootstrap.group(Netty.clientWorkerGroup)
     bootstrap.channel(classOf[NioSocketChannel])
-
     bootstrap.option[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, config.keepAlive)
 
     bootstrap.handler(new ChannelInitializer[SocketChannel] {

--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -100,6 +100,9 @@ private[netty] object Client {
     bootstrap.group(Netty.clientWorkerGroup)
     bootstrap.channel(classOf[NioSocketChannel])
     bootstrap.option[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, config.keepAlive)
+    bootstrap.option[java.lang.Boolean](ChannelOption.TCP_NODELAY, config.tcpNoDelay)
+    config.soSndBuf.foreach(bootstrap.option[java.lang.Integer](ChannelOption.SO_SNDBUF, _))
+    config.soRcvBuf.foreach(bootstrap.option[java.lang.Integer](ChannelOption.SO_RCVBUF, _))
 
     bootstrap.handler(new ChannelInitializer[SocketChannel] {
       def initChannel(ch: SocketChannel): Unit = {
@@ -121,8 +124,8 @@ private[netty] object Client {
   } join
 }
 
-final case class ClientConfig(keepAlive: Boolean, limit: Int)
+final case class ClientConfig(keepAlive: Boolean, limit: Int, tcpNoDelay: Boolean, soSndBuf: Option[Int], soRcvBuf: Option[Int])
 
 object ClientConfig {
-  val Default = ClientConfig(true, 1000)
+  val Default = ClientConfig(true, 1000, false, None, None)
 }

--- a/src/main/scala/scalaz/netty/Netty.scala
+++ b/src/main/scala/scalaz/netty/Netty.scala
@@ -40,13 +40,13 @@ object Netty {
     }
   })
 
-  def server(bind: InetSocketAddress, config: ServerConfig = ServerConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService): Process[Task, (InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])] = {
+  def server(bind: InetSocketAddress, config: ServerConfig = ServerConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService, S: Strategy): Process[Task, (InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])] = {
     Process.await(Server(bind, config)) { server: Server =>
       server.listen onComplete Process.eval(server.shutdown).drain
     }
   }
 
-  def connect(to: InetSocketAddress, config: ClientConfig = ClientConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService): Process[Task, Exchange[ByteVector, ByteVector]] = {
+  def connect(to: InetSocketAddress, config: ClientConfig = ClientConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService, S: Strategy): Process[Task, Exchange[ByteVector, ByteVector]] = {
     Process.await(Client(to, config)) { client: Client =>
       Process(Exchange(client.read, client.write)) onComplete Process.eval(client.shutdown).drain
     }

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -132,7 +132,7 @@ private[netty] object Server {
 
     val serverQueue = async.boundedQueue[(InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])](config.limit)
 
-    bootstrap.group(bossGroup, Netty.workerGroup)
+    bootstrap.group(bossGroup, Netty.serverWorkerGroup)
       .channel(classOf[NioServerSocketChannel])
       .childOption[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, config.keepAlive)
       .childHandler(new ChannelInitializer[SocketChannel] {

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -51,7 +51,7 @@ private[netty] class Server(bossGroup: NioEventLoopGroup, channel: _root_.io.net
   }
 }
 
-private[netty] final class ServerHandler(channel: SocketChannel, serverQueue: async.mutable.Queue[(InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])], limit: Int)(implicit pool: ExecutorService) extends ChannelInboundHandlerAdapter {
+private[netty] final class ServerHandler(channel: SocketChannel, serverQueue: async.mutable.Queue[(InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])], limit: Int)(implicit pool: ExecutorService, S: Strategy) extends ChannelInboundHandlerAdapter {
 
   private val channelConfig = channel.config
 
@@ -124,7 +124,7 @@ private[netty] final class ServerHandler(channel: SocketChannel, serverQueue: as
 }
 
 private[netty] object Server {
-  def apply(bind: InetSocketAddress, config: ServerConfig)(implicit pool: ExecutorService): Task[Server] = Task delay {
+  def apply(bind: InetSocketAddress, config: ServerConfig)(implicit pool: ExecutorService, S: Strategy): Task[Server] = Task delay {
     val bossGroup = new NioEventLoopGroup(config.numThreads)
 
     //val server = new Server(bossGroup, config.limit)


### PR DESCRIPTION
I had some experiments on the back pressure topic. I think the current implementation has not only the problem of a possible performance penalty because of blocking, but also has a potential dead lock scenario which can be demonstrated by the introduced unit tests. 

Basically one can make such a round-trip scenario where the traffic just does not go through, even though the executor threads are idle. I have been investigating this a lot by dedicating different ECs to server/client etc and was not able to resolve the issue with the original code. 

An other issue is that we noticed that we are not able to send through big packets (300k). I believe this also boils down to the BP mechanism as it works with this proposed solution.

_Some thoughts on my approach:_

TCP itself has a nice BP mechanism of its own. (receive window etc.) One can have control over it by setting the `SO_RCVBUF`. This should be exposed in the Configs I believe.

We still need a bp mechanism on the application level, because TCP's one kicks in only if the app is not reading the buffer. Instead of blocking the netty-worker thread we could set the Netty channel's  `setAutoread` option telling not to call us for a while when we have to many messages in our queue. Of course we need to reenable it again, should the queue size go down. By doing this we don't need a bounded queue anymore, as the data size of our queue is basically limited by the socket's receive buffer. I did some testing when I traced the queue size with different limits and buffer sizes. I suggest you to do the same to make sure the solution works.

I have been testing this for a while and I haven't noticed neither performance penalties nor memory issues. I understand this is a major change with risks, so take you time to test as you wish. I found it hard to integrate the concept nicely with FP mindset, so should you have a better approach to do this, let me know.
