### PR TITLE
Back Pressure with Netty's setAutoread

### DIFF
--- a/src/main/scala/scalaz/netty/BPAwareQueue.scala
+++ b/src/main/scala/scalaz/netty/BPAwareQueue.scala
@@ -1,0 +1,58 @@
+package scalaz.netty
+
+import java.util.concurrent.atomic.AtomicLong
+import io.netty.channel.ChannelConfig
+import scalaz.concurrent.{Strategy, Task}
+import scalaz.stream._
+
+
+/**
+ * A wrapper around async queue to implement back pressure by means of calling Netty's ChannelConfig.setAutoRead when needed.
+ *
+ * @param limit the target limit. It's the number of logical messages after which back pressure kicks in. Please note that the actual number of messages in the queue will be
+ * higher as netty will continue flushing its buffer.
+ *
+ * @tparam A the type of used messages
+ */
+private[netty] final class BPAwareQueue[A](val limit: Int) {
+
+  // we don't need a bound here as we do back pressure by calling channelConfig.setAutoRead
+  private val queue = async.unboundedQueue[A](Strategy.Sequential)
+
+  // we do the counting here as getting it from the async queue would introduce a latency
+  private val queueSize = new AtomicLong(0)
+
+  private val lowerBound: Int = Math.max(1, limit / 2)
+
+  def enqueueOne(channelConfig: ChannelConfig, a: A): Task[Unit] = Task.delay(enableBPIfNecessary(channelConfig)).flatMap(b => queue.enqueueOne(a))
+
+  def dequeue(channelConfig: ChannelConfig): Process[Task, A] = queue.dequeue.map { bv =>
+    disableBPIfNecessary(channelConfig)
+    bv
+  }
+
+  def close: Task[Unit] = queue.close
+
+  def fail(rsn: Throwable): Task[Unit] = queue.fail(rsn)
+
+  @inline
+  private def increase: Long = queueSize.incrementAndGet
+
+  @inline
+  private def decrease: Long = queueSize.decrementAndGet
+
+  private def enableBPIfNecessary(channelConfig: ChannelConfig): Unit =
+    if (increase >= limit && channelConfig.isAutoRead) {
+      channelConfig.setAutoRead(false)
+    }
+
+  private def disableBPIfNecessary(channelConfig: ChannelConfig): Unit =
+    if (decrease <= lowerBound && !channelConfig.isAutoRead) {
+      channelConfig.setAutoRead(true)
+    }
+
+}
+
+private[netty] final object BPAwareQueue {
+  def apply[A](limit: Int) = new BPAwareQueue[A](limit)
+}

--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -29,14 +29,13 @@ import java.util.concurrent.ExecutorService
 import _root_.io.netty.bootstrap._
 import _root_.io.netty.buffer._
 import _root_.io.netty.channel._
-import _root_.io.netty.channel.nio._
 import _root_.io.netty.channel.socket._
 import _root_.io.netty.channel.socket.nio._
 import _root_.io.netty.handler.codec._
 
-private[netty] final class Client(channel: _root_.io.netty.channel.Channel, queue: async.mutable.Queue[ByteVector]) {
+private[netty] final class Client(channel: _root_.io.netty.channel.Channel, queue: BPAwareQueue[ByteVector]) {
 
-  def read: Process[Task, ByteVector] = queue.dequeue
+  def read: Process[Task, ByteVector] = queue.dequeue(channel.config)
 
   def write(implicit pool: ExecutorService): Sink[Task, ByteVector] = {
     def inner(bv: ByteVector): Task[Unit] = {
@@ -61,7 +60,7 @@ private[netty] final class Client(channel: _root_.io.netty.channel.Channel, queu
   }
 }
 
-private[netty] final class ClientHandler(queue: async.mutable.Queue[ByteVector]) extends ChannelInboundHandlerAdapter {
+private[netty] final class ClientHandler(queue: BPAwareQueue[ByteVector]) extends ChannelInboundHandlerAdapter {
 
   override def channelInactive(ctx: ChannelHandlerContext): Unit = {
     // if the connection is remotely closed, we need to clean things up on our side
@@ -74,12 +73,13 @@ private[netty] final class ClientHandler(queue: async.mutable.Queue[ByteVector])
     val buf = msg.asInstanceOf[ByteBuf]
     val dst = Array.ofDim[Byte](buf.capacity())
     buf.getBytes(0, dst)
-    val bv = ByteVector.view(dst) 
-    
+    val bv = ByteVector.view(dst)
     buf.release()
 
-    // because this is run and not runAsync, we have backpressure propagation
-    queue.enqueueOne(bv).run
+    val channelConfig = ctx.channel.config
+
+    //this could be run async too, but then we introduce some latency. It's better to run this on the netty worker thread as enqueue uses Strategy.Sequential
+    queue.enqueueOne(channelConfig, bv).run
   }
 
   override def exceptionCaught(ctx: ChannelHandlerContext, t: Throwable): Unit = {
@@ -94,12 +94,15 @@ private[netty] object Client {
     //val client = new Client(config.limit)
     val bootstrap = new Bootstrap
 
-    val queue = async.boundedQueue[ByteVector](config.limit)
+
+    val queue = BPAwareQueue[ByteVector](config.limit)
     
     bootstrap.group(Netty.clientWorkerGroup)
     bootstrap.channel(classOf[NioSocketChannel])
-
     bootstrap.option[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, config.keepAlive)
+    bootstrap.option[java.lang.Boolean](ChannelOption.TCP_NODELAY, config.tcpNoDelay)
+    config.soSndBuf.foreach(bootstrap.option[java.lang.Integer](ChannelOption.SO_SNDBUF, _))
+    config.soRcvBuf.foreach(bootstrap.option[java.lang.Integer](ChannelOption.SO_RCVBUF, _))
 
     bootstrap.handler(new ChannelInitializer[SocketChannel] {
       def initChannel(ch: SocketChannel): Unit = {
@@ -121,8 +124,8 @@ private[netty] object Client {
   } join
 }
 
-final case class ClientConfig(keepAlive: Boolean, limit: Int)
+final case class ClientConfig(keepAlive: Boolean, limit: Int, tcpNoDelay: Boolean, soSndBuf: Option[Int], soRcvBuf: Option[Int])
 
 object ClientConfig {
-  val Default = ClientConfig(true, 1000)
+  val Default = ClientConfig(true, 1000, false, None, None)
 }


### PR DESCRIPTION
I had some experiments on the back pressure topic. I think the current implementation has not only the problem of a possible performance penalty because of blocking, but also has a potential dead lock scenario which can be demonstrated by the introduced unit tests.

Basically one can make such a round-trip scenario where the traffic just does not go through, even though the executor threads are idle. I have been investigating this a lot by dedicating different ECs to server/client etc and was not able to resolve the issue with the original code.

An other issue is that we noticed that we are not able to send through big packets (300k). I believe this also boils down to the BP mechanism as it works with this proposed solution.

Some thoughts on my approach:

TCP itself has a nice BP mechanism of its own. (receive window etc.) One can have control over it by setting the SO_RCVBUF. This should be exposed in the Configs I believe.

We still need a bp mechanism on the application level, because TCP's one kicks in only if the app is not reading the buffer. Instead of blocking the netty-worker thread we could set the Netty channel's setAutoread option telling not to call us for a while when we have to many messages in our queue. Of course we need to reenable it again, should the queue size go down. By doing this we don't need a bounded queue anymore, as the data size of our queue is basically limited by the socket's receive buffer. I did some testing when I traced the queue size with different limits and buffer sizes. I suggest you to do the same to make sure the solution works.

I have been testing this for a while and I haven't noticed neither performance penalties nor memory issues. I understand this is a major change with risks, so take you time to test as you wish. I found it hard to integrate the concept nicely with FP mindset, so should you have a better approach to do this, let me know.
