### PR TITLE
Removed useless ephemeral port from Server API

### DIFF
--- a/src/main/scala/scalaz/netty/Netty.scala
+++ b/src/main/scala/scalaz/netty/Netty.scala
@@ -44,7 +44,7 @@ object Netty {
 
   private[netty] lazy val serverWorkerGroup = new NioEventLoopGroup(1, workerGroup("netty-server-worker"))
 
-  def server(bind: InetSocketAddress, config: ServerConfig = ServerConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService, S: Strategy): Process[Task, (InetSocketAddress, Process[Task, Exchange[ByteVector, ByteVector]])] = {
+  def server(bind: InetSocketAddress, config: ServerConfig = ServerConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService, S: Strategy): Process[Task, Process[Task, Exchange[ByteVector, ByteVector]]] = {
     Process.await(Server(bind, config)) { server: Server =>
       server.listen onComplete Process.eval(server.shutdown).drain
     }

--- a/src/test/scala/scalaz/netty/NettySpecs.scala
+++ b/src/test/scala/scalaz/netty/NettySpecs.scala
@@ -51,11 +51,9 @@ object NettySpecs extends Specification {
     "round trip some simple data" in {
       val addr = new InetSocketAddress("localhost", 9090)
 
-      val server = Netty server addr take 1 flatMap {
-        case (_, incoming) => {
-          incoming flatMap { exchange =>
-            exchange.read take 1 to exchange.write drain
-          }
+      val server = Netty server addr take 1 flatMap { incoming =>
+        incoming flatMap { exchange =>
+          exchange.read take 1 to exchange.write drain
         }
       }
 
@@ -88,11 +86,9 @@ object NettySpecs extends Specification {
     "round trip some simple data to ten simultaneous clients" in {
       val addr = new InetSocketAddress("localhost", 9090)
 
-      val server = merge.mergeN(Netty server addr map {
-        case (_, incoming) => {
-          incoming flatMap { exchange =>
-            exchange.read take 1 to exchange.write drain
-          }
+      val server = merge.mergeN(Netty server addr map { incoming =>
+        incoming flatMap { exchange =>
+          exchange.read take 1 to exchange.write drain
         }
       })
 


### PR DESCRIPTION
There's really no reason to have the ephemeral port in the `Server` API.  You can't do anything with it other than mask it out.  Obviously, this is an incompatible change, but harmlessly so.
