### PR TITLE
Lost data near connection closure

### DIFF
--- a/src/main/scala/scalaz/netty/Netty.scala
+++ b/src/main/scala/scalaz/netty/Netty.scala
@@ -52,7 +52,7 @@ object Netty {
 
   def connect(to: InetSocketAddress, config: ClientConfig = ClientConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService, S: Strategy): Process[Task, Exchange[ByteVector, ByteVector]] = {
     Process.await(Client(to, config)) { client: Client =>
-      Process(Exchange(client.read, client.write)) onComplete Process.eval(client.shutdown).drain
+      Process(Exchange(client.read, client.write)) onComplete client.shutdown
     }
   }
 


### PR DESCRIPTION
This fixes #23, though unfortunately I couldn't find a way to test it.  Netty is very good at avoiding using the `exceptionCaught` callback except in really dire straights, and I'm not quite sure how to make it happen with a local socket (i.e. in the test suite).  Help would be very much appreciated in figuring out how to test this!
