### PR TITLE
Fixed readme for removal of ephemeral address

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ val address = new InetSocketAddress("localhost", 9090)
 val EchoServer = merge.mergeN(Netty server address map { incoming =>
   for {
     exchange <- incoming
-    _ <- Process.eval(log(s"accepted connection from $addr"))
+    _ <- Process.eval(log("accepted connection"))
     _ <- exchange.read to exchange.write
   } yield ()
 })


### PR DESCRIPTION
This PR fixes an example from README. It didn't build due to absence of `addr`.
