### PR TITLE
various optimizations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,10 @@ libraryDependencies ++= Seq(
 
   "io.netty"          %  "netty-codec"   % "4.0.29.Final",
 
+  "io.netty"          %  "netty-transport-native-epoll"   % "4.0.29.Final",
+
+  "io.netty"          % "netty-transport-native-epoll" % "4.0.29.Final" classifier "linux-x86_64",
+
   "org.scodec"        %% "scodec-bits"   % "1.0.9")
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/scalaz/netty/EventLoopType.scala
+++ b/src/main/scala/scalaz/netty/EventLoopType.scala
@@ -1,0 +1,62 @@
+package scalaz.netty
+
+import java.util.concurrent.ThreadFactory
+
+import io.netty.channel.Channel
+import io.netty.channel.EventLoopGroup
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.epoll.EpollEventLoopGroup
+import io.netty.channel.epoll.EpollServerSocketChannel
+import io.netty.channel.ServerChannel
+import io.netty.channel.epoll.EpollSocketChannel
+import io.netty.channel.socket.nio.NioSocketChannel
+import io.netty.channel.socket.nio.NioServerSocketChannel
+
+sealed trait EventLoopType {
+  private[netty] def serverWorkerGroup(numberOfThreads: Int) = eventLoopGroup(numberOfThreads, "netty-server-worker")
+
+  private[netty] def clientWorkerGroup(numberOfThreads: Int) = eventLoopGroup(numberOfThreads, "netty-client-worker")
+
+  private[netty] def bossGroup: EventLoopGroup = eventLoopGroup(1, "netty-boss-group")
+
+  private[netty] def eventLoopGroup(numberOfThreads: Int, name: String): EventLoopGroup
+
+  private[netty] def channel: Class[_ <: Channel]
+
+  private[netty] def serverChannel: Class[_ <: ServerChannel]
+}
+
+
+object EventLoopType {
+
+  object Select extends EventLoopType {
+
+    private[netty] def eventLoopGroup(numberOfThreads: Int, name: String) = new NioEventLoopGroup(numberOfThreads, workerGroup(name))
+
+    private[netty] def serverChannel = classOf[NioServerSocketChannel]
+
+    private[netty] def channel: Class[_ <: Channel] = classOf[NioSocketChannel]
+
+  }
+
+  object Epoll extends EventLoopType {
+
+    private[netty] def eventLoopGroup(numberOfThreads: Int, name: String) = new EpollEventLoopGroup(numberOfThreads, workerGroup(name))
+
+    private[netty] def serverChannel = classOf[EpollServerSocketChannel]
+
+    private[netty] def channel = classOf[EpollSocketChannel]
+
+  }
+
+  private def workerGroup(name: String) = new ThreadFactory {
+    def newThread(r: Runnable): Thread = {
+      val back = new Thread(r)
+      back.setName(name)
+      back.setDaemon(true) // we're never going to clean this up
+      back.setPriority(8) // get in, and get out.  fast.
+      back
+    }
+  }
+
+}

--- a/src/main/scala/scalaz/netty/Netty.scala
+++ b/src/main/scala/scalaz/netty/Netty.scala
@@ -23,26 +23,12 @@ import stream._
 import scodec.bits.ByteVector
 
 import java.net.InetSocketAddress
-import java.util.concurrent.{ExecutorService, ThreadFactory}
+import java.util.concurrent.ExecutorService
 
 import _root_.io.netty.channel._
 import _root_.io.netty.channel.nio.NioEventLoopGroup
 
 object Netty {
-
-  private[netty] def workerGroup(name: String) = new ThreadFactory {
-    def newThread(r: Runnable): Thread = {
-      val back = new Thread(r)
-      back.setName(name)
-      back.setDaemon(true) // we're never going to clean this up
-      back.setPriority(8) // get in, and get out.  fast.
-      back
-    }
-  }
-
-  private[netty] lazy val clientWorkerGroup = new NioEventLoopGroup(1, workerGroup("netty-client-worker"))
-
-  private[netty] lazy val serverWorkerGroup = new NioEventLoopGroup(1, workerGroup("netty-server-worker"))
 
   def server(bind: InetSocketAddress, config: ServerConfig = ServerConfig.Default)(implicit pool: ExecutorService = Strategy.DefaultExecutorService, S: Strategy): Process[Task, Process[Task, Exchange[ByteVector, ByteVector]]] = {
     Process.await(Server(bind, config)) { server: Server =>


### PR DESCRIPTION
Various performance optimizations following the guidelines of [Norman Maurer](https://github.com/normanmaurer). Check [this](http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#1.0) out.

changes are:
- using `PooledByteBufAllocator`s
- using native epoll on Linux instead of select
- dispatching writes to the eventloop thread to avoid contention
- using a single boss thread and multiple worker threads in Server

This version improves latency about 10% in my use-case. :-)
