### PR TITLE
Feature/upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.11.7
-  - 2.12.0-M2
+  - 2.11.8
+#  - 2.12.0-M4
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ If you want to be able to use snapshot releases, replace `releases` with `snapsh
 libraryDependencies += "org.scalaz.netty" %% "scalaz-netty" % "0.2"
 ```
 
-Builds are published for Scala 2.11.7 and 2.12.0-M2.  The latest stable release is **0.2**.  The upstream dependencies for this project include the following:
+Builds are published for Scala 2.11.8.  The latest stable release is **0.2**.  The upstream dependencies for this project include the following:
 
-- scalaz 7.1.3
-- scalaz-stream 0.7.2a
-- scodec-bits 1.0.9
-- netty 4.0.29.Final
+- scalaz 7.1.7
+- scalaz-stream 0.8.0
+- scodec-bits 1.0.12
+- netty 4.0.36.Final
 
 Snapshot releases follow the version scheme `master-<sha1>`, where the "`sha1`" component is the Git commit that was snapshotted.  Not all commits will have corresponding snapshot releases.  You can browse the list of snapshot releases [on bintray](https://bintray.com/rr/snapshots/scalaz-netty/view).
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 RichRelevance
+ * Copyright 2016 RichRelevance
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -21,23 +21,23 @@ organization := "org.scalaz.netty"
 
 name := "scalaz-netty"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.12.0-M2")
+//crossScalaVersions := Seq(scalaVersion.value, "2.12.0-M4")
 
 resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
 
 libraryDependencies ++= Seq(
-  "org.scalaz"        %% "scalaz-core"   % "7.1.3",
-  "org.scalaz.stream" %% "scalaz-stream" % "0.7.2a",
+  "org.scalaz"        %% "scalaz-core"   % "7.1.7",
+  "org.scalaz.stream" %% "scalaz-stream" % "0.8",
 
-  "io.netty"          %  "netty-codec"   % "4.0.29.Final",
+  "io.netty"          %  "netty-codec"   % "4.0.36.Final",
 
-  "org.scodec"        %% "scodec-bits"   % "1.0.9")
+  "org.scodec"        %% "scodec-bits"   % "1.0.12")
 
 libraryDependencies ++= Seq(
-  "org.specs2"     %% "specs2-core" % "3.6.4"  % "test",
-  "org.scalacheck" %% "scalacheck"  % "1.12.4" % "test")
+  "org.specs2"     %% "specs2-core" % "3.6.6"  % "test",
+  "org.scalacheck" %% "scalacheck"  % "1.13.0" % "test")
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 RichRelevance
+ * Copyright 2016 RichRelevance
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 RichRelevance
+ * Copyright 2016 RichRelevance
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/scalaz/netty/Netty.scala
+++ b/src/main/scala/scalaz/netty/Netty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 RichRelevance
+ * Copyright 2016 RichRelevance
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 RichRelevance
+ * Copyright 2016 RichRelevance
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/scalaz/netty/NettySpecs.scala
+++ b/src/test/scala/scalaz/netty/NettySpecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 RichRelevance
+ * Copyright 2016 RichRelevance
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
upgrade copyright

upgrade dependencies, preparing for a scalaz-stream 0.8 compatible release.  (a 0.8a compatible one will follow)
