### PR TITLE
When copying a ByteBuf to a ByteVector, only copy the relevant bytes

### DIFF
--- a/src/main/scala/scalaz/netty/Client.scala
+++ b/src/main/scala/scalaz/netty/Client.scala
@@ -78,8 +78,8 @@ private[netty] final class ClientHandler(queue: BPAwareQueue[ByteVector], halt: 
 
   override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
     val buf = msg.asInstanceOf[ByteBuf]
-    val dst = Array.ofDim[Byte](buf.capacity())
-    buf.getBytes(0, dst)
+    val dst = Array.ofDim[Byte](buf.readableBytes())
+    buf.readBytes(dst)
     val bv = ByteVector.view(dst)
 
     buf.release()

--- a/src/main/scala/scalaz/netty/Server.scala
+++ b/src/main/scala/scalaz/netty/Server.scala
@@ -79,8 +79,8 @@ private[netty] final class ServerHandler(channel: SocketChannel, serverQueue: as
 
   override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
     val buf = msg.asInstanceOf[ByteBuf]
-    val dst = Array.ofDim[Byte](buf.capacity())
-    buf.getBytes(0, dst)
+    val dst = Array.ofDim[Byte](buf.readableBytes())
+    buf.readBytes(dst)
 
     val bv = ByteVector.view(dst)
 


### PR DESCRIPTION
While fiddling around with scalaz-netty during @djspiewak's workshop on scalaz-streams at flatMap(Oslo) 2016 I noticed something odd: 

Using the echo server example from the docs, but with `codeFrames = false`, I got the following behavior playing around with netca (input prefixed with `<`, output with `>`)t:

```
$ nc -c localhost 6667
< foo<enter>
> foo         
< <enter>
>             
> o           // wait, what?
```

It turns out that the translation from Netty's `ByteBuf`s to `ByteVector`s is based on a misunderstanding of `ByteBuf`. Essentially, it copies the _whole_ buffer, not just the relevant parts.  Add reuse of memory to the mix, and we get the above behavior.

The JavaDoc at http://netty.io/4.1/api/io/netty/buffer/ByteBuf.html explains it pretty well:  the relevant bits of a `ByteBuf` are from `readerIndex`, inclusive, to `writerIndex`, exclusive.  Luckily, there are useful accessors both for the number of readable bytes and to copy said bytes to an array.
