### PR TITLE
Support Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
   - 2.11.8
-#  - 2.12.0-M4
+  - 2.12.0
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -14,16 +14,22 @@ resolvers += "RichRelevance Bintray" at "http://dl.bintray.com/rr/releases"
 If you want to be able to use snapshot releases, replace `releases` with `snapshots`.  With the resolver configured, add the following dependency specification:
 
 ```sbt
-libraryDependencies += "org.scalaz.netty" %% "scalaz-netty" % "0.4"
+libraryDependencies += "org.scalaz.netty" %% "scalaz-netty" % "0.4.1"
 ```
 
-Builds are published for Scala 2.11.8.  The latest stable release is **0.4**.
+Builds are published for Scala 2.11.8, and for 2.12.x for versions at or above 0.4.1.  The latest stable release is **0.4.1**.
 
 Versions that end in 'a' in the 0.3.x series use scalaz 7.2.x, versions without use scalaz 7.1.x.
 
 The 0.3.2 versions contain one additional feature over the 0.3, https://github.com/RichRelevance/scalaz-netty/pull/28, which has only been tested on Linux and may not work elsewhere.
 
 The upstream dependencies for this project include the following:
+
+For version 0.4.1
+- scalaz 7.2.7
+- scalaz-stream 0.8.6a
+- scodec-bits 1.1.2
+- netty 4.0.42.Final
 
 For version 0.4:
 - scalaz 7.2.5

--- a/build.sbt
+++ b/build.sbt
@@ -22,25 +22,25 @@ name := "scalaz-netty"
 
 scalaVersion := "2.11.8"
 
-//crossScalaVersions := Seq(scalaVersion.value, "2.12.0-M4")
+crossScalaVersions := Seq(scalaVersion.value, "2.12.0")
 
 resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
 
 libraryDependencies ++= Seq(
-  "org.scalaz"        %% "scalaz-core"   % "7.2.5",
-  "org.scalaz.stream" %% "scalaz-stream" % "0.8.4a",
+  "org.scalaz"        %% "scalaz-core"   % "7.2.7",
+  "org.scalaz.stream" %% "scalaz-stream" % "0.8.6a",
 
-  "io.netty"          %  "netty-codec"   % "4.0.40.Final",
+  "io.netty"          %  "netty-codec"   % "4.0.42.Final",
 
-  "io.netty"          %  "netty-transport-native-epoll"   % "4.0.40.Final",
+  "io.netty"          %  "netty-transport-native-epoll"   % "4.0.42.Final",
 
-  "io.netty"          %  "netty-transport-native-epoll" % "4.0.40.Final" classifier "linux-x86_64",
+  "io.netty"          %  "netty-transport-native-epoll" % "4.0.42.Final" classifier "linux-x86_64",
 
-  "org.scodec"        %% "scodec-bits"   % "1.1.0")
+  "org.scodec"        %% "scodec-bits"   % "1.1.2")
 
 libraryDependencies ++= Seq(
-  "org.specs2"     %% "specs2-core" % "3.8.4"  % "test",
-  "org.scalacheck" %% "scalacheck"  % "1.13.0" % "test")
+  "org.specs2"     %% "specs2-core" % "3.8.6"  % "test",
+  "org.scalacheck" %% "scalacheck"  % "1.13.4" % "test")
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/"))
 

--- a/src/test/scala/scalaz/netty/NettySpecs.scala
+++ b/src/test/scala/scalaz/netty/NettySpecs.scala
@@ -145,16 +145,16 @@ object NettySpecs extends Specification {
 
         val server = for {
           incoming <- Netty server addr take 1
-          Exchange(_, write) <- incoming
-          _ <- write take 1 evalMap {
+          exch <- incoming
+          _ <- exch.write take 1 evalMap {
             _ (data)
           }
         } yield () // close connection instantly
 
         val client = for {
           _ <- time.sleep(500 millis)(Strategy.DefaultStrategy, scheduler) ++ Process.emit(())
-          Exchange(read, _) <- Netty connect addr
-          back <- read take 1
+          exch <- Netty connect addr
+          back <- exch.read take 1
         } yield back
 
         val driver: Process[Task, ByteVector] = server.drain merge client
@@ -171,14 +171,14 @@ object NettySpecs extends Specification {
 
         val server = for {
           incoming <- Netty server addr take 1
-          Exchange(read, _) <- incoming
-          back <- read take 1
+          exch <- incoming
+          back <- exch.read take 1
         } yield back
 
         val client = for {
           _ <- time.sleep(500 millis)(Strategy.DefaultStrategy, scheduler) ++ Process.emit(())
-          Exchange(_, write) <- Netty connect addr
-          _ <- write take 1 evalMap {
+          exch <- Netty connect addr
+          _ <- exch.write take 1 evalMap {
             _ (data)
           }
         } yield () // close connection instantly


### PR DESCRIPTION
+compile works, +test:compile does not.  Various for comprehensions no longer compile now that withFilter is required for use.